### PR TITLE
CMake: Disable pthreads by default on Windows & !MinGW.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,12 @@ set(CMAKE_C_STANDARD 99)
 
 option(BUILD_SHARED_LIBS "Build libbz3 as a shared library" ON)
 option(BZIP3_BUILD_APPS "Build bzip3 applications" ON)
-option(BZIP3_ENABLE_PTHREAD "Enable use of pthread library" ON)
+if(WIN32)
+  set(BZIP3_ENABLE_PTHREAD_DEFAULT OFF)
+else()
+  set(BZIP3_ENABLE_PTHREAD_DEFAULT ON)
+endif()
+option(BZIP3_ENABLE_PTHREAD "Enable use of pthread library" "${BZIP3_ENABLE_PTHREAD_DEFAULT}")
 option(BZIP3_ENABLE_ARCH_NATIVE "Enable CPU-specific optimizations" OFF)
 option(BZIP3_ENABLE_STATIC_EXE "Enable static builds of the executable" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_C_STANDARD 99)
 
 option(BUILD_SHARED_LIBS "Build libbz3 as a shared library" ON)
 option(BZIP3_BUILD_APPS "Build bzip3 applications" ON)
-if(WIN32)
+if(WIN32 AND NOT (MINGW OR CYGWIN))
   set(BZIP3_ENABLE_PTHREAD_DEFAULT OFF)
 else()
   set(BZIP3_ENABLE_PTHREAD_DEFAULT ON)


### PR DESCRIPTION
Attempting to build with pthreads turned on on Windows triggers a build failure due to missing pthreads headers. As Windows isn't a pthreads platform, it seems like this should be off by default.