### PR TITLE
cmake: Set CMAKE_CURRENT_SOURCE_DIR to path of ${BZIP3_MAN}.in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,15 +141,17 @@ if(BZIP3_BUILD_APPS)
         bz3most.1
         bzip3.1)
     foreach(BZIP3_MAN ${BZIP3_MANS})
-      if(EXISTS ${BZIP3_MAN}.in)
+      if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${BZIP3_MAN}.in)
         string(TIMESTAMP MAN_DATE "%d %B %Y" UTC)
         set(TRANSFORMED_PACKAGE_NAME ${CMAKE_PROJECT_NAME})
         set(MAN_DATE ${MAN_DATE})
         set(VERSION ${PROJECT_VERSION})
-        configure_file(${BZIP3_MAN}.in ${CMAKE_CURRENT_BINARY_DIR}/${BZIP3_MAN}
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${BZIP3_MAN}.in
+		       ${CMAKE_CURRENT_BINARY_DIR}/${BZIP3_MAN}
                        @ONLY)
       else()
-        configure_file(${BZIP3_MAN} ${CMAKE_CURRENT_BINARY_DIR}/${BZIP3_MAN}
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${BZIP3_MAN}
+		       ${CMAKE_CURRENT_BINARY_DIR}/${BZIP3_MAN}
                        COPYONLY)
       endif()
       install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BZIP3_MAN}


### PR DESCRIPTION
If CMAKE_CURRENT_SOURCE_DIR is not specified to ${BZIP3_MAN}.in, it will refer to the current directory, which will result in an error if user builds with out-of-source builds.
This sets CMAKE_CURRENT_SOURCE_DIR and supports out-of-source builds.

```
$ mkdir t && cd t && cmake ..
-- The C compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
CMake Error: File /home/iwamatsu/dev/bzip3/bz3grep.1 does not exist.
CMake Error at CMakeLists.txt:152 (configure_file):
  configure_file Problem configuring file

CMake Error: File /home/iwamatsu/dev/bzip3/bz3less.1 does not exist.
CMake Error at CMakeLists.txt:152 (configure_file):
  configure_file Problem configuring file

[...]
```