### PR TITLE
`build.yml`: Run once per week to detect CI breakage early (fixes #179)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build
 on:
   push:
   pull_request:
+  schedule:
+    - cron: '0 2 * * 5'  # Every Friday at 2am
 
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build
 
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
 
 jobs:
 


### PR DESCRIPTION
Fixes #179